### PR TITLE
fixed bug of multiple academic year and term

### DIFF
--- a/src/html/admin.html
+++ b/src/html/admin.html
@@ -13,7 +13,6 @@
     <link href="../assets/fontawesome/css/solid.css" rel="stylesheet" />
 
     <script type="module" src="../js//admin.js" defer></script>
-    <script type="module" src="../js/settings.js" defer></script>
   </head>
 
   <body>


### PR DESCRIPTION
Initially, the academic year and term select fields in the "Change Academic" section of the settings were showing duplicate entries. This issue was caused by the `settings.js` file being included both in `admin.html` and imported in `admin.js`, leading to each function in `settings.js` being called twice. To resolve this, I removed the call from the HTML file. The functionality is now working as expected.